### PR TITLE
Add API for svg gradient overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 **/out-tsc
 # solution-specific compile
 **/build-all.sh
-**/Dockerfile
 
 # dependencies
 **/node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3] - 2020-02-24
-### Added
-- Add `edits.overlayWithGradient` handling to create a buffer of an SVG gradient and composite the result over the 
-  processed image
-
 ## [4.2] - 2020-02-06
 ### Added
 - Honor outputFormat Parameter from the pull request [#117](https://github.com/awslabs/serverless-image-handler/pull/117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3] - 2020-02-24
+### Added
+- Add `edits.overlayWithGradient` handling to create a buffer of an SVG gradient and composite the result over the 
+  processed image
+
 ## [4.2] - 2020-02-06
 ### Added
 - Honor outputFormat Parameter from the pull request [#117](https://github.com/awslabs/serverless-image-handler/pull/117)

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2020-02-24
+### Added
+- `edits.overlayWithGradient` handling to create a buffer of an SVG gradient and composite the result over the
+  processed image
+- `Dockerfile`
+
 ## [1.6.0] - 2021-02-19
 ### Changed
 - `toFormat` to `outputFormat` parameter to be consistent with sharp API. `toFormat` will still be supported until 2.0.

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:12-buster-slim
+
+RUN apt-get update && apt-get install -y zip unzip && rm -rf /var/cache/apt/*
+
+CMD [ "/bin/sh" ]


### PR DESCRIPTION
This will add handling for an `edits.overlayWithGradient` key. If key is existent (e.g. `edits.overlayWithGradient: 1`), a default gradient will be applied to the center of the source image by utilizing the `sharpjs` `composite` API.

A possible configuration could be
```
edits.overlayWithGradient = {
  "top": "10%",
  "left": "60%",
  "radius": 120,
  "stops": [
    ["0%", {"r": 0, "g": 255, "b": 128", "alpha": 0.5}],
    ["50%", {"r": 128, "g": 0, "b": 128", "alpha": 0.8}],
    ["100%", {"r": 0, "g": 0, "b": 0", "alpha": 1}]
  ]
}