### PR TITLE
Fix gradient accept float

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2020-05-11
+### Fixed
+- regex in `overlayWithGradient` for `top`, `left` and `radius` to accept float values
+
 ## [1.7.0] - 2020-02-24
 ### Added
 - `edits.overlayWithGradient` handling to create a buffer of an SVG gradient and composite the result over the

--- a/source/image-handler/image-handler.js
+++ b/source/image-handler/image-handler.js
@@ -316,7 +316,7 @@ class ImageHandler {
                 case 'top':
                 case 'left':
                 case 'radius':
-                    if (!/^\d+[p%]?$/.test(String(value))) {
+                    if (!/^[0-9]+(\.[0-9]+)?[p%]?$/.test(String(value))) {
                         throw ({
                             status: 400,
                             message: `Invalid argument 'edits.overlayWithGradient.${key}' provided for ImageHandler::generateGradient: ${value}`

--- a/source/image-handler/test/test-image-handler.js
+++ b/source/image-handler/test/test-image-handler.js
@@ -487,7 +487,7 @@ describe('generateGradient()', function() {
                 overlayWithGradient: {
                     top: '20%',
                     left: '55p',
-                    radius: '120',
+                    radius: '120.5',
                     stops: [],
                 }
             }
@@ -505,7 +505,7 @@ describe('generateGradient()', function() {
                 imageHandler.generateGradient(edits, metadata),
                 '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="200">' +
                     '<defs>' +
-                        '<radialGradient id="rgrad" cx="55%" cy="20%" r="120" gradientUnits="userSpaceOnUse">' +
+                        '<radialGradient id="rgrad" cx="55%" cy="20%" r="120.5" gradientUnits="userSpaceOnUse">' +
                         '</radialGradient>' +
                     '</defs>' +
                     '<rect x="0" y="0" width="100" height="200" fill="url(#rgrad)" />' +
@@ -541,23 +541,9 @@ describe('generateGradient()', function() {
 
         it(`Should throw an error for invalid values`,
             async function() {
-            edits.overlayWithGradient.top = 'foo';
+            edits.overlayWithGradient.top = '10.';
             edits.overlayWithGradient.left = null;
             edits.overlayWithGradient.radius = {};
-
-            assert.throws(() => imageHandler.generateGradient(edits, metadata));
-        });
-
-        it(`Should throw an error for null offsets`,
-            async function() {
-            edits.overlayWithGradient.top = null;
-
-            assert.throws(() => imageHandler.generateGradient(edits, metadata));
-        });
-
-        it(`Should throw an error for non-string offsets`,
-            async function() {
-            edits.overlayWithGradient.top = {};
 
             assert.throws(() => imageHandler.generateGradient(edits, metadata));
         });


### PR DESCRIPTION
Fixes a regex in the `overlayWithGradient` validation process to accept float values.

![image](https://user-images.githubusercontent.com/23153018/117787157-7a0c1880-b246-11eb-8c02-1ab3a0911e8e.png)
