### PR TITLE
Add DEFAULT_FORMAT option for a default output format of images

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.8.0] - 2020-06-29
+### Added
+- `DEFAULT_FORMAT` option to always convert an image to a given format when AutoWebP is not used and no other outputFormat is defined via sharp edits
+
 ## [1.7.1] - 2020-05-11
 ### Fixed
 - regex in `overlayWithGradient` for `top`, `left` and `radius` to accept float values

--- a/deployment/serverless-image-handler.template
+++ b/deployment/serverless-image-handler.template
@@ -63,6 +63,12 @@
             "Default" : 1,
             "Type" : "Number",
             "AllowedValues" : [ 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653 ]
+        },
+        "DefaultFormat" : {
+            "Description" : "Always convert an image to this format when AutoWebP is not used and no other outputFormat edit parameter is given",
+            "Default" : "",
+            "Type" : "String",
+            "AllowedValues" : [ "jpeg", "jpg", "png", "webp", "tiff", "heif", "gif" ]
         }
     },
     "Metadata": {
@@ -78,7 +84,7 @@
                 },
                 {
                     "Label": { "default": "Optimization" },
-                    "Parameters": [ "AutoWebP", "MaxDimensions", "AllowedDimensions" ]
+                    "Parameters": [ "DefaultFormat", "AutoWebP", "MaxDimensions", "AllowedDimensions" ]
                 },
                 {
                     "Label": { "default": "Demo UI" },
@@ -408,6 +414,9 @@
                 "Timeout": 30,
                 "Environment" : {
                     "Variables" : {
+                        "DEFAULT_FORMAT" : {
+                            "Ref" : "DefaultFormat"
+                        },
                         "AUTO_WEBP" : {
                             "Ref" : "AutoWebP"
                         },
@@ -878,6 +887,10 @@
         "AutoWebPEnabled" : {
             "Description" : "Indicates whether automatic WebP transformation has been enabled for the image handler API.",
             "Value" : { "Ref" : "AutoWebP" }
+        },
+        "DefaultFormat" : {
+            "Description" : "Use DefaultFormat when AutoWebPEnabled is disabled and no outputFormat edit was given.",
+            "Value" : { "Ref" : "DefaultFormat" }
         },
         "MaximumDimensions" : {
             "Description" : "Maximum dimension allowed for image scaling",

--- a/deployment/serverless-image-handler.template
+++ b/deployment/serverless-image-handler.template
@@ -67,8 +67,7 @@
         "DefaultFormat" : {
             "Description" : "Always convert an image to this format when AutoWebP is not used and no other outputFormat edit parameter is given",
             "Default" : "",
-            "Type" : "String",
-            "AllowedValues" : [ "jpeg", "jpg", "png", "webp", "tiff", "heif", "gif" ]
+            "Type" : "String"
         }
     },
     "Metadata": {
@@ -889,7 +888,7 @@
             "Value" : { "Ref" : "AutoWebP" }
         },
         "DefaultFormat" : {
-            "Description" : "Use DefaultFormat when AutoWebPEnabled is disabled and no outputFormat edit was given.",
+            "Description" : "Use DefaultFormat when AutoWebPEnabled is not applicable and no outputFormat edit was given.",
             "Value" : { "Ref" : "DefaultFormat" }
         },
         "MaximumDimensions" : {

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -346,7 +346,9 @@ class ImageRequest {
             return 'webp';
         } else if (this.requestType === 'Default') {
             const decoded = this.decodeRequest(event);
-            return decoded.outputFormat;
+            if (decoded.outputFormat) {
+                return decoded.outputFormat;
+            }
         }
 
         const defaultFormat = DEFAULT_FORMAT ? `${DEFAULT_FORMAT}`.toLowerCase() : '';

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -337,7 +337,9 @@ class ImageRequest {
      * @param {Object} event - The request body.
      */
     getOutputFormat(event) {
-        const autoWebP = `${process.env.AUTO_WEBP}`.toLowerCase() || 'no';
+        const { DEFAULT_FORMAT, AUTO_WEBP } = process.env
+
+        const autoWebP = AUTO_WEBP ? `${AUTO_WEBP}`.toLowerCase() : 'no';
         const headers = event.headers || {};
         const acceptHeader = headers.Accept || headers.accept;
         if (autoWebP === 'yes' && typeof acceptHeader === 'string' && acceptHeader.includes('image/webp')) {
@@ -345,6 +347,11 @@ class ImageRequest {
         } else if (this.requestType === 'Default') {
             const decoded = this.decodeRequest(event);
             return decoded.outputFormat;
+        }
+
+        const defaultFormat = DEFAULT_FORMAT ? `${DEFAULT_FORMAT}`.toLowerCase() : '';
+        if (defaultFormat !== '') {
+            return defaultFormat;
         }
 
         return null;


### PR DESCRIPTION
This PR adds an option to configure a default output format for images with allowed values of:
`[ "jpeg", "jpg", "png", "webp", "tiff", "heif", "gif" ]`.
The image handler will fall back to the given value if the no `outputFormat` is given in the sharp edits JSON object and no WebP accept header is given.

Reason for this PR is a case in an iOS App that is not able to handle `webp` output images provided by the image handler when the source file is a `webp` file. In that case the request by the device does not contain an accept header for the `webp` image format and no other conversion is happening to the source file. With this flag the source file will be converted to the given format if no `webp` accept header is given.

### Test results (via AWS Lambda UI)
`DEFAULT_FORMAT` no defined or empty string
<img width="1075" alt="webp" src="https://user-images.githubusercontent.com/24268434/123829951-28f1da00-d903-11eb-9966-6cf0be457036.png">

`DEFAULT_FORMAT="jpeg"`
<img width="1521" alt="jpeg" src="https://user-images.githubusercontent.com/24268434/123829929-242d2600-d903-11eb-9fa5-6e9a151d4459.png">

Aside:
Also this PR includes a Fix where `${process.env.AUTO_WEBP}`.toLowerCase()` could yield `'undefined'` if the environment variable was not set.