### PR TITLE
Feature persist trimmed image

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2020-07-16
+### Added
+- `persistTrimmedImage` and `PERSIST_TRIMMED_IMAGE` option to store a `_trimmed` image version alongside the original and reuse it for subsequent requests to improve performance.
 
 ## [1.8.0] - 2020-06-29
 ### Added

--- a/deployment/serverless-image-handler.template
+++ b/deployment/serverless-image-handler.template
@@ -68,7 +68,7 @@
             "Description" : "Always convert an image to this format when AutoWebP is not used and no other outputFormat edit parameter is given",
             "Default" : "",
             "Type" : "String"
-        }
+        },
         "PersistTrimmedImage" : {
             "Description" : "Store a _trimmed image version alongside the original and reuse it for subsequent requests to improve performance.",
             "Default" : 0,

--- a/deployment/serverless-image-handler.template
+++ b/deployment/serverless-image-handler.template
@@ -69,6 +69,11 @@
             "Default" : "",
             "Type" : "String"
         }
+        "PersistTrimmedImage" : {
+            "Description" : "Store a _trimmed image version alongside the original and reuse it for subsequent requests to improve performance.",
+            "Default" : 0,
+            "Type" : "Number"
+        }
     },
     "Metadata": {
         "AWS::CloudFormation::Interface": {
@@ -83,7 +88,7 @@
                 },
                 {
                     "Label": { "default": "Optimization" },
-                    "Parameters": [ "DefaultFormat", "AutoWebP", "MaxDimensions", "AllowedDimensions" ]
+                    "Parameters": [ "DefaultFormat", "AutoWebP", "MaxDimensions", "AllowedDimensions", "PersistTrimmedImage" ]
                 },
                 {
                     "Label": { "default": "Demo UI" },
@@ -415,6 +420,9 @@
                     "Variables" : {
                         "DEFAULT_FORMAT" : {
                             "Ref" : "DefaultFormat"
+                        },
+                        "PERSIST_TRIMMED_IMAGE" : {
+                            "Ref" : "PersistTrimmedImage"
                         },
                         "AUTO_WEBP" : {
                             "Ref" : "AutoWebP"

--- a/source/image-handler/image-handler.js
+++ b/source/image-handler/image-handler.js
@@ -50,6 +50,12 @@ class ImageHandler {
         }
     }
 
+    async trim(originalImage) {
+        const image = sharp(originalImage, { failOnError: false });
+        const buffer = await image.trim().toBuffer();
+        return buffer
+    }
+
     /**
      * Applies image modifications to the original image based on edits
      * specified in the ImageRequest.


### PR DESCRIPTION
This adds an option to store a trimmed image version alongside the original image upon the first request to improve performance.

During testing we found out, that trimming an image seems to be very expensive to do. In order to not always trim the image anew with every request that misses our cache, here we add an option to store the requested image as `<key>_trimmed.<format>` (e.g. `Rfgs32_trimmed.jpg`) in the same S3 location as the original image.

To enable this option there are two ways: Either on a Function-level via the environment variable `PERSIST_TRIMMED_IMAGE` set to `Yes`, or on a request level via the `persistTrimmedImage` flag added to the JSON object (e.g. `{"key":"<bucketPath>.jpg","persistTrimmedImage":1,edits":{"trim": 1,...`). In either case, the image needs to have the `"trim": 1` edit flag active.

In my testing with a Staging build, I could shave off at least 30-50% of the function execution time for every subsequent request. The execution time of the initial request is the same, since we store the trimmed image in S3 in a non-blocking way and return the trimmed version early to use it for the edits.

### Test Result
Note: results are only an indication and might behave differently on production, but look promising overall

#### Before
![Screenshot 2021-07-20 at 10 28 26](https://user-images.githubusercontent.com/24268434/126288218-43c7fc6f-5f7a-4ef4-a2e8-c729eaead0b3.png)


#### After
![Screenshot 2021-07-20 at 10 30 17](https://user-images.githubusercontent.com/24268434/126291311-9a1896d2-c071-42d5-b732-81977180ec3b.png)
